### PR TITLE
Update parameter use in get_season() function

### DIFF
--- a/chapter2/EEG Signals.ipynb
+++ b/chapter2/EEG Signals.ipynb
@@ -183,7 +183,7 @@
     "    return trendpoly(X)\n",
     "\n",
     "def get_season(s, yearly_periods=4, degree=3):\n",
-    "    X = [i%(365/4) for i in range(0, len(s))]\n",
+    "    X = [i%(365/yearly_periods) for i in range(0, len(s))]\n",
     "    seasonal = fit(X, s.values, degree)\n",
     "    return pd.Series(data=seasonal, index=s.index)\n",
     "\n",


### PR DESCRIPTION
An integer is being used instead of the yearly_periods parameter in the get_season() function. The function works as is, but is not generalizable to seasonality of other yearly_periods values.